### PR TITLE
reuse AVAudioConverter to prevent clicking/crackling noise

### DIFF
--- a/ios/Classes/FlautoPlayerEngine.mm
+++ b/ios/Classes/FlautoPlayerEngine.mm
@@ -157,6 +157,7 @@
         AVAudioFormat* playerFormat;
         AVAudioFormat* outputFormat;
         AVAudioOutputNode* outputNode;
+        AVAudioConverter* converter;
         CFTimeInterval mStartPauseTime ; // The time when playback was paused
 	CFTimeInterval systemTime ; //The time when  StartPlayer() ;
         double mPauseTime ; // The number of seconds during the total Pause mode
@@ -232,6 +233,11 @@
                          }
                         [engine stop];
                         engine = nil;
+                    
+                        if (converter != nil)
+                        {
+                            converter = nil;
+                        }
                 }
        }
 
@@ -301,7 +307,11 @@
                         AVAudioPCMBuffer* thePCMOutputBuffer = [[AVAudioPCMBuffer alloc] initWithPCMFormat: outputFormat frameCapacity: frameLength];
                         thePCMOutputBuffer.frameLength = 0;
 
-                        AVAudioConverter* converter = [[AVAudioConverter alloc]initFromFormat: playerFormat toFormat: outputFormat];
+                        if (converter == nil) 
+                        {
+                                converter = [[AVAudioConverter alloc]initFromFormat: playerFormat toFormat: outputFormat];
+                        }
+
                         NSError* error;
                         [converter convertToBuffer: thePCMOutputBuffer error: &error withInputFromBlock: inputBlock];
                          // if (r == AVAudioConverterOutputStatus_HaveData || true)


### PR DESCRIPTION
I detected a crackling sound on every chunk of data sent when streaming audio. It seems that the problem is when the data is resampled/converted. According to this https://stackoverflow.com/questions/64553738/avaudioconverter-corrupts-data we should reuse the AVAudioConverter instead of creating a new one on each chunk.

I confirmed the crackling sound is now gone with this fix.