### PR TITLE
Fix audio recording issue with 16Khz recording devices

### DIFF
--- a/ios/Classes/FlautoRecorderEngine.mm
+++ b/ios/Classes/FlautoRecorderEngine.mm
@@ -91,15 +91,14 @@
                         return buffer;
                 };
                 NSError* error;
-                BOOL r = [converter convertToBuffer: convertedBuffer error: &error withInputFromBlock: inputBlock];
-                if (!r)
+                [converter convertToBuffer: convertedBuffer error: &error withInputFromBlock: inputBlock];
+                if (error != nil)
                 {
-                        //NSString* s =  error.localizedDescription;
-                        
-                        //s = error.localizedFailureReason;
-                        [flautoRecorder logDebug:  @"Error [converter convertToBuffer: convertedBuffer error: &error withInputFromBlock: inputBlock] during AudioRecorderEngine::AudioRecorderEngine"];
+                        NSString *errorMessage = [NSString stringWithFormat: @"[converter convertToBuffer:] error: %@", error.localizedDescription];
+                        [flautoRecorder logDebug: errorMessage];
                         return;
                 }
+
                 int n = [convertedBuffer frameLength];
                 int16_t *const  bb = [convertedBuffer int16ChannelData][0];
                 NSData* b = [[NSData alloc] initWithBytes: bb length: n * 2 ];


### PR DESCRIPTION
Hi @Larpoux!

I'm working with @ericadu, and we were able to diagnose and come up with a fix for an issue she reported: 
https://github.com/Canardoux/flutter_sound/issues/885. I tested and made sure the fix in this PR works, but feel free to use this PR as inspiration if you would rather make a different fix!

### Summary

This PR fixes an error handling issue with audio recording. In `FlautoRecorderEngine`, the original code was unintentionally casting an enum to a BOOL, which caused unexpected audio recording issues.

The original code was doing this:
```
BOOL r = [converter convertToBuffer: convertedBuffer error: &error withInputFromBlock: inputBlock];
if (!r) { error }
```

It should instead be something like this:
```
AVAudioConverterOutputStatus status = [converter convertToBuffer: convertedBuffer error: &error withInputFromBlock: inputBlock];
BOOL r = (status == .haveData || status == .inputRanDry) 
if (!r) { error }
```

### Why is this only breaking for 16Khz devices

I believe this only affects 16Khz devices because `convertToBuffer` returns a different value for 16Khz vs other devices:
16Khz: AVAudioConverterOutputStatus_haveData 
`>16Khz: AVAudioConverterOutputStatus_inputRanDry

Since `haveData` has an enum value of 0, and `inputRanDry` is 1, the line
```
BOOL r = [converter convertToBuffer: ... ]
```
was evaluating to `NO` for 16Khz devices (BAD!) and `YES` for > 16Khz devices.

I don't exactly know why > 16Khz recording devices returns `inputRanDry` (maybe the way the `convertedBuffer` is set up?), but recording appears to be working fine for those devices despite the `inputRanDry` enum value.

### Testing
With flutter_sound 9.2.10, I observed that my 16Khz Bluetooth device was consistently unable to record audio (it was always empty), but my 24Khz (Airpod gen 2) and 48Khz (iPhone 13 built in mic) devices were able to record.

Once I made this changes, I was able to successfully record with all 3.