### PR TITLE
Add bufferSizeMs parameter to recorder interface

### DIFF
--- a/android/src/main/java/com/dooboolab/TauEngine/FlautoRecorder.java
+++ b/android/src/main/java/com/dooboolab/TauEngine/FlautoRecorder.java
@@ -252,6 +252,7 @@ public class FlautoRecorder
 		Integer                         sampleRate          ,
 		Integer                         numChannels         ,
 		Integer                         bitRate             ,
+		Integer                         bufferSizeMs        ,
 		String                     		path                ,
 		t_AUDIO_SOURCE                  _audioSource        ,
 		boolean 						toStream
@@ -278,7 +279,7 @@ public class FlautoRecorder
 		}
 		try
 		{
-				recorder._startRecorder( numChannels, sampleRate, bitRate, codec, path, audioSource, this );
+				recorder._startRecorder( numChannels, sampleRate, bitRate, bufferSizeMs, codec, path, audioSource, this);
 				if (subsDurationMillis > 0)
 						setTimer(subsDurationMillis);
 

--- a/android/src/main/java/com/dooboolab/TauEngine/FlautoRecorderEngine.java
+++ b/android/src/main/java/com/dooboolab/TauEngine/FlautoRecorderEngine.java
@@ -240,7 +240,7 @@ public class FlautoRecorderEngine
 				tabCodec[codec.ordinal()]
 		);
 		int requestedBufferSize = (bufferSizeMs * sampleRate / 1000) * 2; // Assume 16bit PCM
-		int bufferSize = Integer.max(minBufferSize * 2, requestedBufferSize);
+		int bufferSize = Integer.max(minBufferSize, requestedBufferSize);
 
 		recorder = new AudioRecord(audioSource,
 				sampleRate,

--- a/android/src/main/java/com/dooboolab/TauEngine/FlautoRecorderInterface.java
+++ b/android/src/main/java/com/dooboolab/TauEngine/FlautoRecorderInterface.java
@@ -29,6 +29,7 @@ public interface FlautoRecorderInterface
 			Integer numChannels,
 			Integer sampleRate,
 			Integer bitRate,
+			Integer bufferSizeMs,
 			t_CODEC codec,
 			String path,
 			int audioSource,

--- a/android/src/main/java/com/dooboolab/TauEngine/FlautoRecorderMedia.java
+++ b/android/src/main/java/com/dooboolab/TauEngine/FlautoRecorderMedia.java
@@ -125,6 +125,7 @@ public class FlautoRecorderMedia
 			Integer numChannels,
 			Integer sampleRate,
 			Integer bitRate,
+			Integer bufferSizeMs,
 			t_CODEC codec,
 			String path,
 			int audioSource,

--- a/ios/Classes/FlautoRecorder.h
+++ b/ios/Classes/FlautoRecorder.h
@@ -57,7 +57,8 @@
                 toPath: (NSString*)path
                 channels: (int)numChannels
                 sampleRate: (long)sampleRate
-                bitRate: (long)bitRate;
+                bitRate: (long)bitRate
+                bufferSizeMs: (int)bufferSizeMs;
                 
 - (void)stopRecorder;
 - (void)setSubscriptionDuration: (long)millisec;

--- a/ios/Classes/FlautoRecorder.mm
+++ b/ios/Classes/FlautoRecorder.mm
@@ -198,11 +198,13 @@ AudioRecInterface* audioRec;
                 channels: (int)numChannels
                 sampleRate: (long)sampleRate
                 bitRate: (long)bitRate
+                bufferSizeMs: (int)bufferSizeMs
 {
         NSMutableDictionary* audioSettings = [NSMutableDictionary dictionaryWithObjectsAndKeys:
                                  [NSNumber numberWithLong: sampleRate], AVSampleRateKey,
                                  [NSNumber numberWithInt: formats[codec] ], AVFormatIDKey,
                                  [NSNumber numberWithInt: numChannels ], AVNumberOfChannelsKey,
+                                 [NSNumber numberWithInt: bufferSizeMs ], @"bufferSizeMs",
                          nil];
 
         // If bitrate is defined, we use it, otherwise use the OS default

--- a/ios/Classes/FlautoRecorderEngine.mm
+++ b/ios/Classes/FlautoRecorderEngine.mm
@@ -45,6 +45,9 @@
 
         AVAudioInputNode* inputNode = [engine inputNode];
         AVAudioFormat* inputFormat = [inputNode outputFormatForBus: 0];
+        NSNumber* bufferSizeMs = audioSettings [@"bufferSizeMs"];
+        double samplePerMs = [inputFormat sampleRate] / 1000.0;
+        unsigned int bufferSize = (unsigned int)(samplePerMs * [bufferSizeMs doubleValue]);
         double sRate = [inputFormat sampleRate];
         // -AVAudioChannelCount channelCount = [inputFormat channelCount];
         AVAudioChannelLayout* layout = [inputFormat channelLayout];
@@ -59,7 +62,6 @@
         
         NSNumber* nbChannels = audioSettings [AVNumberOfChannelsKey];
         NSNumber* sampleRate = audioSettings [AVSampleRateKey];
-        //sampleRate = [NSNumber numberWithInt: 44000];
         AVAudioFormat* recordingFormat = [[AVAudioFormat alloc] initWithCommonFormat: AVAudioPCMFormatInt16 sampleRate: sampleRate.doubleValue channels: (unsigned int)(nbChannels.unsignedIntegerValue) interleaved: YES];
         AVAudioConverter* converter = [[AVAudioConverter alloc]initFromFormat: inputFormat toFormat: recordingFormat];
         NSFileManager* fileManager = [NSFileManager defaultManager];
@@ -76,7 +78,7 @@
         }
 
 
-        [inputNode installTapOnBus: 0 bufferSize: 20480 format: inputFormat block:
+        [inputNode installTapOnBus: 0 bufferSize: bufferSize format: inputFormat block:
         ^(AVAudioPCMBuffer * _Nonnull buffer, AVAudioTime * _Nonnull when)
         {
                 inputStatus = AVAudioConverterInputStatus_HaveData ;


### PR DESCRIPTION
This PR allows us to resolve [this issue](https://github.com/Canardoux/flutter_sound/issues/681). It adds `bufferSizeMs` parameter to Android and iOS implementation. Hence, one can record to a stream with chunks having specific size. 