### PR TITLE
Using MediaPlayer's prepareAsync instead of prepare

### DIFF
--- a/android/src/main/java/xyz/canardoux/TauEngine/FlautoPlayer.java
+++ b/android/src/main/java/xyz/canardoux/TauEngine/FlautoPlayer.java
@@ -182,7 +182,8 @@ public class FlautoPlayer implements MediaPlayer.OnErrorListener {
 		}
 
 		try {
-			if (fromURI == null && (codec == t_CODEC.pcm16 || codec == t_CODEC.pcmFloat32)) {
+			boolean useAudioTrackEngine = fromURI == null && (codec == t_CODEC.pcm16 || codec == t_CODEC.pcmFloat32);
+			if (useAudioTrackEngine) {
 				player = new FlautoPlayerEngine();
 			} else {
 				player = new FlautoPlayerMedia(this);
@@ -190,7 +191,11 @@ public class FlautoPlayer implements MediaPlayer.OnErrorListener {
 			String path = Flauto.getPath(fromURI);
 
 			player._startPlayer(codec, path, sampleRate, numChannels, interleaved, bufferSize, false, this);
-			play();
+			if (useAudioTrackEngine) {
+				play();
+			} else {
+				// FlautoPlayerMedia automatically calls `play()` once MediaPlayer is prepared
+			}
 		} catch (Exception e) {
 			logError("startPlayer() exception");
 			return false;

--- a/android/src/main/java/xyz/canardoux/TauEngine/FlautoPlayerMedia.java
+++ b/android/src/main/java/xyz/canardoux/TauEngine/FlautoPlayerMedia.java
@@ -49,7 +49,7 @@ class FlautoPlayerMedia extends FlautoPlayerEngineInterface
 		mediaPlayer.setOnPreparedListener(mp -> {flautoPlayer.play(); flautoPlayer.onPrepared();});
 		mediaPlayer.setOnCompletionListener(mp -> flautoPlayer.onCompletion());
 		mediaPlayer.setOnErrorListener(flautoPlayer);
-		mediaPlayer.prepare();
+		mediaPlayer.prepareAsync();
 	}
 
 	void _play()


### PR DESCRIPTION
Fixes https://github.com/Canardoux/flutter_sound/issues/985, I believe

Using MediaPlayer's asynchronous [`prepareAsync()`](https://developer.android.com/reference/android/media/MediaPlayer#prepareAsync()) instead of synchronous [`prepare()`](https://developer.android.com/reference/android/media/MediaPlayer#prepare()), to avoid ANRs when there is no network connection when trying to play from a remote URL

I've tested this on a couple Android devices but haven't widely tested in production yet, since I wasn't able to get a fork of flutter_sound to point to a fork of flutter_sound_core. Happy to try this in production if you can provide some guidance on how to set it up, though!