### PR TITLE
Fixes Canardoux/flutter_sound#1189

### DIFF
--- a/android/src.sav/main/java/xyz/canardoux/TauEngine/FlautoPlayer.java
+++ b/android/src.sav/main/java/xyz/canardoux/TauEngine/FlautoPlayer.java
@@ -294,9 +294,6 @@ public class FlautoPlayer implements MediaPlayer.OnErrorListener {
 
 									long position = player._getCurrentPosition();
 									long duration = player._getDuration();
-									if (position > duration) {
-										position = duration;
-									}
 									m_callBack.updateProgress(position, duration);
 								}
 							} catch (Exception e) {
@@ -490,9 +487,6 @@ public class FlautoPlayer implements MediaPlayer.OnErrorListener {
 		if (player != null) {
 			position = player._getCurrentPosition();
 			duration = player._getDuration();
-		}
-		if (position > duration) {
-			position = duration;
 		}
 
 		Map<String, Object> dic = new HashMap<String, Object>();

--- a/android/src/main/java/xyz/canardoux/TauEngine/FlautoPlayer.java
+++ b/android/src/main/java/xyz/canardoux/TauEngine/FlautoPlayer.java
@@ -336,9 +336,6 @@ public class FlautoPlayer implements MediaPlayer.OnErrorListener {
 
 									long position = player._getCurrentPosition();
 									long duration = player._getDuration();
-									if (position > duration) {
-										position = duration;
-									}
 									m_callBack.updateProgress(position, duration);
 								}
 							} catch (Exception e) {
@@ -532,9 +529,6 @@ public class FlautoPlayer implements MediaPlayer.OnErrorListener {
 		if (player != null) {
 			position = player._getCurrentPosition();
 			duration = player._getDuration();
-		}
-		if (position > duration) {
-			position = duration;
 		}
 
 		Map<String, Object> dic = new HashMap<String, Object>();


### PR DESCRIPTION
Since MediaPlayer stops when the stream finishes, I removed the position > duration check because it was problematic. With that check in place, if the audio is streamed from the server without a Content-Length header and using Transfer-Encoding: chunked, the duration is always 0, and as a result, the position is also 0, which is incorrect.