### PR TITLE
Modified FlautoRecorderEngine.java to re-use buffers and avoid GC churn

### DIFF
--- a/android/src/main/java/xyz/canardoux/TauEngine/FlautoPlayer.java
+++ b/android/src/main/java/xyz/canardoux/TauEngine/FlautoPlayer.java
@@ -539,11 +539,21 @@ public class FlautoPlayer implements MediaPlayer.OnErrorListener {
 	}
 
 	void logDebug(String msg) {
-		m_callBack.log(t_LOG_LEVEL.DBG, msg);
+		mainHandler.post(new Runnable() {
+			@Override
+			public void run() {
+				m_callBack.log(t_LOG_LEVEL.DBG, msg);
+			}
+		});
 	}
 
 	void logError(String msg) {
-		m_callBack.log(t_LOG_LEVEL.ERROR, msg);
+		mainHandler.post(new Runnable() {
+			@Override
+			public void run() {
+				m_callBack.log(t_LOG_LEVEL.ERROR, msg);
+			}
+		});
 	}
 
 }

--- a/android/src/main/java/xyz/canardoux/TauEngine/FlautoPlayerEngine.java
+++ b/android/src/main/java/xyz/canardoux/TauEngine/FlautoPlayerEngine.java
@@ -116,6 +116,8 @@ class FlautoPlayerEngine extends FlautoPlayerEngineInterface {
 		}
 
 		public void run() {
+			AudioTrack track = audioTrack;
+			if (track == null) return;
 			int ln = 0; // The number of bytes accepted (and perhaps played) by the device
 			if (mCodec == Flauto.t_CODEC.pcmFloat32)
 			{
@@ -124,11 +126,11 @@ class FlautoPlayerEngine extends FlautoPlayerEngineInterface {
 				FloatBuffer fbuf = buf.asFloatBuffer();
 				float[] ff = new float[mData.length/4];
 				fbuf.get(ff);
-				ln = audioTrack.write(ff, 0, mData.length/4, AudioTrack.WRITE_BLOCKING);
+				ln = track.write(ff, 0, mData.length/4, AudioTrack.WRITE_BLOCKING);
 				ln = 4 * ln;
 			} else
 			{
-				ln = audioTrack.write(mData, 0, mData.length, AudioTrack.WRITE_BLOCKING);
+				ln = track.write(mData, 0, mData.length, AudioTrack.WRITE_BLOCKING);
 			}
 			mSession.needSomeFood(1);
 		}
@@ -142,6 +144,8 @@ class FlautoPlayerEngine extends FlautoPlayerEngineInterface {
 		}
 
 		public void run() {
+			AudioTrack track = audioTrack;
+			if (track == null) return;
 			int nbrChannels = mData.size();
 			int frameSize = mData.get(0).length;
 			int ln = nbrChannels * frameSize;
@@ -158,7 +162,7 @@ class FlautoPlayerEngine extends FlautoPlayerEngineInterface {
 				}
 
 			}
-			int	r = audioTrack.write(interleavedData, 0, ln, AudioTrack.WRITE_BLOCKING);
+			int	r = track.write(interleavedData, 0, ln, AudioTrack.WRITE_BLOCKING);
 			mSession.needSomeFood(1);
 		}
 	}
@@ -171,6 +175,8 @@ class FlautoPlayerEngine extends FlautoPlayerEngineInterface {
 		}
 
 		public void run() {
+			AudioTrack track = audioTrack;
+			if (track == null) return;
 			int ln = 0; // The number of bytes accepted (and perhaps played) by the device
 			int nbrOfChannels = mData.size();
 			int frameSize = mData.get(0).length;
@@ -183,7 +189,7 @@ class FlautoPlayerEngine extends FlautoPlayerEngineInterface {
 					r[ i * nbrOfChannels + channel] = b[i];
 				}
 			}
-			ln = audioTrack.write(r, 0, r.length, AudioTrack.WRITE_BLOCKING);
+			ln = track.write(r, 0, r.length, AudioTrack.WRITE_BLOCKING);
 			mSession.needSomeFood(1);
 		}
 	}

--- a/flutter_sound_core.podspec
+++ b/flutter_sound_core.podspec
@@ -31,7 +31,7 @@ It has been extracted to be isolated from Flutter and can be used with other fra
   s.ios.deployment_target = '12.0'
 
   s.source_files = 'ios/Classes/*'
-  s.frameworks = 'AVFoundation', 'MediaPlayer'
+  s.frameworks = 'AVFoundation', 'MediaPlayer', 'AudioToolbox'
 
 
 end

--- a/ios/Classes/FlautoPlayerEngine.mm
+++ b/ios/Classes/FlautoPlayerEngine.mm
@@ -338,6 +338,7 @@
         #define NB_BUFFERS 4
         - (int) feed: (NSArray*)data interleaved: (bool)interleaved
         {
+            @autoreleasepool {
                 //NSMutableArray* data = [[NSMutableArray alloc] init];
                 //NSData* d = data[0];
                 //assert (audioData.count > 0); // Something wrong
@@ -423,8 +424,10 @@
                         [playerNode scheduleBuffer: thePCMOutputBuffer  completionHandler:
                         ^(void)
                         {
+                            @autoreleasepool {
                                 dispatch_async(dispatch_get_main_queue(),
                                 ^{
+                                    @autoreleasepool {
                                         --ready; // The Device has sent its packet. One less to send.
                                         assert(ready < NB_BUFFERS || !interleaved);
                                         if (self ->waitingBlock != nil)
@@ -441,7 +444,9 @@
                                                 [self ->flutterSoundPlayer  audioPlayerDidFinishPlaying: true];
 
                                         }
+                                    }
                                 });
+                            }
 
                         }];
                         return ln;
@@ -453,6 +458,7 @@
                         waitingBlock = data;
                         return 0;
                 }
+            }
          }
 
 

--- a/ios/Classes/FlautoRecorder.mm
+++ b/ios/Classes/FlautoRecorder.mm
@@ -274,9 +274,17 @@ AudioRecInterface* audioRec;
 
         if(codec == pcm16 || codec == pcmFloat32)
         {
+            // Use AudioQueuePCMRecorder instead of AudioRecorderEngine (AVAudioEngine+tap).
+            // AVAudioEngine.inputNode.installTapOnBus produces silence on macOS Catalyst
+            // ("Made for iPad" mode) — AudioQueueNewInput with PCM16 uses the same HAL
+            // path as AVAudioRecorder and works correctly on both iOS and macOS Catalyst.
             try
             {
-                audioRec = new AudioRecorderEngine(codec, path, audioSettings, bufferSize, enableVoiceProcessing, self );
+                long rate = [[audioSettings objectForKey: AVSampleRateKey] longValue];
+                int ch    = [[audioSettings objectForKey: AVNumberOfChannelsKey] intValue];
+                if (rate <= 0) rate = 16000;
+                if (ch   <= 0) ch   = 1;
+                audioRec = new AudioQueuePCMRecorder(path, (double)rate, ch, self);
             } catch ( NSException* e)
             {
                 return false;

--- a/ios/Classes/FlautoRecorderEngine.h
+++ b/ios/Classes/FlautoRecorderEngine.h
@@ -103,5 +103,44 @@ public:
 
 };
 
+#include <AudioToolbox/AudioToolbox.h>
+
+/// A PCM stream recorder built directly on AudioQueueNewInput.
+/// Unlike AudioRecorderEngine (AVAudioEngine+installTapOnBus), this uses the
+/// same low-level AudioQueue path as AVAudioRecorder, which works correctly
+/// on macOS Catalyst ("Made for iPad" / Mac mode).
+/// Raw PCM-16 bytes are delivered to the FlautoRecorder stream callback.
+class AudioQueuePCMRecorder : public AudioRecInterface
+{
+private:
+    AudioQueueRef audioQueue;
+    NSMutableArray<NSValue*>* buffers;
+    long dateCumul;
+    long previousTS;
+    int status;
+    double sampleRate;
+    int numChannels;
+    NSFileHandle* fileHandle; // non-nil when saving to file
+    
+    static void AudioQueueCallback(void* userdata,
+                                   AudioQueueRef queue,
+                                   AudioQueueBufferRef buffer,
+                                   const AudioTimeStamp* startTime,
+                                   UInt32 numPackets,
+                                   const AudioStreamPacketDescription* packetDesc);
+    void computePeakLevelForInt16Blk(int16_t* pt, int ln);
+    
+public:
+    /* ctor */ AudioQueuePCMRecorder(NSString* path, double sampleRate, int numChannels, FlautoRecorder* owner);
+    /* dtor */ virtual ~AudioQueuePCMRecorder();
+    virtual int startRecorder();
+    virtual void stopRecorder();
+    virtual void resumeRecorder();
+    virtual void pauseRecorder();
+    virtual NSNumber* recorderProgress();
+    virtual NSNumber* dbPeakProgress();
+    virtual int getStatus();
+};
+
 #endif // #ifdef __cplusplus
 #endif /* FlautoRecorderEngine_h */

--- a/ios/Classes/FlautoRecorderEngine.mm
+++ b/ios/Classes/FlautoRecorderEngine.mm
@@ -81,6 +81,7 @@
          [inputNode installTapOnBus: 0 bufferSize: (int)bufferSize format: nil block:
          ^(AVAudioPCMBuffer* _Nonnull buffer, AVAudioTime* _Nonnull when)
          {
+             @autoreleasepool {
                          inputStatus = AVAudioConverterInputStatus_HaveData ;
                          AVAudioPCMBuffer* convertedBuffer = [[AVAudioPCMBuffer alloc]initWithPCMFormat: recordingFormat frameCapacity: [buffer frameCapacity]];
                                                   
@@ -176,6 +177,7 @@
                                      });
                               } // Not interleaved
                          } // (frameLength > 0)
+             }
          }];
      
 }

--- a/ios/Classes/FlautoRecorderEngine.mm
+++ b/ios/Classes/FlautoRecorderEngine.mm
@@ -47,13 +47,27 @@
         
    
         
+        // On macOS Catalyst (iOS app on Mac / "Made for iPad" mode), the AVAudioEngine's
+        // inputNode reports 0 channels unless the AVAudioSession is explicitly activated
+        // at the native level before we query the format. Without this, the tap produces
+        // silence / zero-byte callbacks even though bytes appear to flow at the Dart level.
+        NSError* sessionError = nil;
+        [[AVAudioSession sharedInstance] setCategory: AVAudioSessionCategoryPlayAndRecord
+                                         withOptions: AVAudioSessionCategoryOptionDefaultToSpeaker | AVAudioSessionCategoryOptionAllowBluetooth
+                                               error: &sessionError];
+        if (sessionError) {
+            NSLog(@"[FlautoRecorderEngine] AVAudioSession setCategory error: %@", sessionError);
+        }
+        [[AVAudioSession sharedInstance] setActive: YES error: &sessionError];
+        if (sessionError) {
+            NSLog(@"[FlautoRecorderEngine] AVAudioSession setActive error: %@", sessionError);
+        }
+
         AVAudioInputNode* inputNode = [engine inputNode];
         AVAudioFormat* inputFormat = [inputNode outputFormatForBus: 0];
+        NSLog(@"[FlautoRecorderEngine] inputNode format: ch=%u sr=%.0f", (unsigned)[inputFormat channelCount], [inputFormat sampleRate]);
         int outputChannelCount = [audioSettings [AVNumberOfChannelsKey]  intValue];
         NSNumber* sampleRate = audioSettings [AVSampleRateKey];
-        //int inputChannelCount = [inputFormat channelCount];
-        //int inputSampleRrate = [inputFormat sampleRate];
-        //AVAudioCommonFormat cf = [inputFormat commonFormat];
         bool interleaved = ![audioSettings [AVLinearPCMIsNonInterleaved] boolValue];
 
         NSFileManager* fileManager = [NSFileManager defaultManager];
@@ -404,3 +418,180 @@ int avAudioRec::getStatus()
 }
 
 
+
+//-----------------------------------------------------------------------------------------------------------------------------------------
+// AudioQueuePCMRecorder
+// Uses AudioQueueNewInput with raw PCM-16 -- the same HAL path as AVAudioRecorder --
+// which works on macOS Catalyst where AVAudioEngine.inputNode tap produces silence.
+// Raw PCM bytes are delivered to FlautoRecorder via recordingData: stream callback.
+//-----------------------------------------------------------------------------------------------------------------------------------------
+
+static const int kNumBuffers = 3;
+static const int kBufferSizeBytes = 3200; // ~100ms at 16kHz mono PCM16
+
+void AudioQueuePCMRecorder::AudioQueueCallback(
+        void* userdata,
+        AudioQueueRef queue,
+        AudioQueueBufferRef buffer,
+        const AudioTimeStamp* startTime,
+        UInt32 numPackets,
+        const AudioStreamPacketDescription* packetDesc)
+{
+    AudioQueuePCMRecorder* self = (AudioQueuePCMRecorder*)userdata;
+    if (self->status != 2) {
+        AudioQueueEnqueueBuffer(queue, buffer, 0, NULL);
+        return;
+    }
+
+    NSUInteger byteCount = buffer->mAudioDataByteSize;
+    if (byteCount > 0) {
+        int16_t* samples = (int16_t*)buffer->mAudioData;
+        int sampleCount = (int)(byteCount / 2);
+        self->computePeakLevelForInt16Blk(samples, sampleCount);
+
+        NSData* data = [NSData dataWithBytes:buffer->mAudioData length:byteCount];
+        if (self->fileHandle != nil) {
+            [self->fileHandle writeData:data];
+        } else {
+            FlautoRecorder* recorder = self->flautoRecorder;
+            dispatch_async(dispatch_get_main_queue(), ^{
+                @autoreleasepool {
+                    if (recorder == nil || self->status != 2) return;
+                    [recorder recordingData:data];
+                }
+            });
+        }
+    }
+    AudioQueueEnqueueBuffer(queue, buffer, 0, NULL);
+}
+
+void AudioQueuePCMRecorder::computePeakLevelForInt16Blk(int16_t* pt, int ln)
+{
+    for (int i = 0; i < ln; ++pt, ++i) {
+        int cur = abs(*pt);
+        if (cur > maxAmplitude) maxAmplitude = cur;
+    }
+    ++nbrSamples;
+}
+
+AudioQueuePCMRecorder::AudioQueuePCMRecorder(NSString* path, double sr, int ch, FlautoRecorder* owner)
+{
+    flautoRecorder = owner;
+    sampleRate = sr;
+    numChannels = ch;
+    audioQueue = nil;
+    dateCumul = 0;
+    previousTS = 0;
+    status = 0;
+
+    if (path != nil && path != (id)[NSNull null]) {
+        [[NSFileManager defaultManager] createFileAtPath:path contents:nil attributes:nil];
+        fileHandle = [NSFileHandle fileHandleForWritingAtPath:path];
+    } else {
+        fileHandle = nil;
+    }
+
+    AudioStreamBasicDescription fmt;
+    memset(&fmt, 0, sizeof(fmt));
+    fmt.mFormatID         = kAudioFormatLinearPCM;
+    fmt.mFormatFlags      = kAudioFormatFlagIsSignedInteger | kAudioFormatFlagIsPacked;
+    fmt.mSampleRate       = sr;
+    fmt.mChannelsPerFrame = (UInt32)ch;
+    fmt.mBitsPerChannel   = 16;
+    fmt.mBytesPerFrame    = (UInt32)(2 * ch);
+    fmt.mFramesPerPacket  = 1;
+    fmt.mBytesPerPacket   = fmt.mBytesPerFrame;
+
+    OSStatus err = AudioQueueNewInput(&fmt, AudioQueueCallback, this, nil, nil, 0, &audioQueue);
+    if (err != noErr) {
+        NSLog(@"[AudioQueuePCMRecorder] AudioQueueNewInput failed: %d", (int)err);
+        audioQueue = nil;
+        return;
+    }
+    NSLog(@"[AudioQueuePCMRecorder] Created AudioQueue PCM16 %.0fHz %dch", sr, ch);
+
+    for (int i = 0; i < kNumBuffers; i++) {
+        AudioQueueBufferRef buf;
+        AudioQueueAllocateBuffer(audioQueue, kBufferSizeBytes, &buf);
+        AudioQueueEnqueueBuffer(audioQueue, buf, 0, NULL);
+    }
+}
+
+AudioQueuePCMRecorder::~AudioQueuePCMRecorder()
+{
+    if (audioQueue != nil) {
+        AudioQueueDispose(audioQueue, true);
+        audioQueue = nil;
+    }
+    [fileHandle closeFile];
+}
+
+int AudioQueuePCMRecorder::startRecorder()
+{
+    if (audioQueue == nil) return 0;
+    OSStatus err = AudioQueueStart(audioQueue, nil);
+    if (err != noErr) {
+        NSLog(@"[AudioQueuePCMRecorder] AudioQueueStart failed: %d", (int)err);
+        return 0;
+    }
+    previousTS = (long)(CACurrentMediaTime() * 1000);
+    status = 2;
+    NSLog(@"[AudioQueuePCMRecorder] Recording started OK");
+    return status;
+}
+
+void AudioQueuePCMRecorder::stopRecorder()
+{
+    if (audioQueue != nil) AudioQueueStop(audioQueue, true);
+    [fileHandle closeFile];
+    if (previousTS != 0) {
+        dateCumul += (long)(CACurrentMediaTime() * 1000) - previousTS;
+        previousTS = 0;
+    }
+    status = 0;
+    NSLog(@"[AudioQueuePCMRecorder] Recording stopped");
+}
+
+void AudioQueuePCMRecorder::resumeRecorder()
+{
+    if (audioQueue == nil) return;
+    AudioQueueStart(audioQueue, nil);
+    previousTS = (long)(CACurrentMediaTime() * 1000);
+    status = 2;
+}
+
+void AudioQueuePCMRecorder::pauseRecorder()
+{
+    if (audioQueue == nil) return;
+    AudioQueuePause(audioQueue);
+    if (previousTS != 0) {
+        dateCumul += (long)(CACurrentMediaTime() * 1000) - previousTS;
+        previousTS = 0;
+    }
+    status = 1;
+}
+
+NSNumber* AudioQueuePCMRecorder::recorderProgress()
+{
+    long r = dateCumul;
+    if (previousTS != 0) r += (long)(CACurrentMediaTime() * 1000) - previousTS;
+    return [NSNumber numberWithLong:r];
+}
+
+NSNumber* AudioQueuePCMRecorder::dbPeakProgress()
+{
+    if (nbrSamples > 0) {
+        previousAmplitude = maxAmplitude;
+        maxAmplitude = 0;
+        nbrSamples = 0;
+    }
+    double max = previousAmplitude;
+    if (max == 0.0) return [NSNumber numberWithDouble:0.0];
+    double db = 20.0 * log10((max / 51805.5336) / 0.0002);
+    return [NSNumber numberWithDouble:db];
+}
+
+int AudioQueuePCMRecorder::getStatus()
+{
+    return status;
+}

--- a/ios/Classes/FlautoRecorderEngine.mm
+++ b/ios/Classes/FlautoRecorderEngine.mm
@@ -83,7 +83,11 @@
          {
              @autoreleasepool {
                          inputStatus = AVAudioConverterInputStatus_HaveData ;
-                         AVAudioPCMBuffer* convertedBuffer = [[AVAudioPCMBuffer alloc]initWithPCMFormat: recordingFormat frameCapacity: [buffer frameCapacity]];
+                         
+                         double ratio = recordingFormat.sampleRate / inputFormat.sampleRate;
+                         AVAudioFrameCount requiredCapacity = (AVAudioFrameCount)((double)[buffer frameCapacity] * ratio) + 1024;
+                         
+                         AVAudioPCMBuffer* convertedBuffer = [[AVAudioPCMBuffer alloc]initWithPCMFormat: recordingFormat frameCapacity: requiredCapacity];
                                                   
                          AVAudioConverterInputBlock inputBlock =
                          ^AVAudioBuffer*(AVAudioPacketCount inNumberOfPackets, AVAudioConverterInputStatus *outStatus)
@@ -128,11 +132,13 @@
                                      {
                                          dispatch_async(dispatch_get_main_queue(),
                                         ^{
-                                             if (flautoRecorder == nil || status == 0) // something bad in the recorder : skip the callback
-                                             {
-                                                 return;
-                                             }
-                                             [flautoRecorder  recordingData: data];
+                                            @autoreleasepool {
+                                                 if (flautoRecorder == nil || status == 0) // something bad in the recorder : skip the callback
+                                                 {
+                                                     return;
+                                                 }
+                                                 [flautoRecorder  recordingData: data];
+                                            }
                                          });
                                      }
                                      
@@ -162,18 +168,20 @@
                                      }
                                      dispatch_async(dispatch_get_main_queue(),
                                     ^{
-                                         if (flautoRecorder == nil || getStatus() == 0) // something bad
-                                         {
-                                             return;
-                                         }
-                                         if (coder == pcmFloat32)
-                                         {
-                                             [flautoRecorder  recordingDataFloat32: recdata];
-                                         } else
-                                         if (coder == pcm16)
-                                         {
-                                             [flautoRecorder  recordingDataInt16: recdata];
-                                         }
+                                        @autoreleasepool {
+                                             if (flautoRecorder == nil || getStatus() == 0) // something bad
+                                             {
+                                                 return;
+                                             }
+                                             if (coder == pcmFloat32)
+                                             {
+                                                 [flautoRecorder  recordingDataFloat32: recdata];
+                                             } else
+                                             if (coder == pcm16)
+                                             {
+                                                 [flautoRecorder  recordingDataInt16: recdata];
+                                             }
+                                        }
                                      });
                               } // Not interleaved
                          } // (frameLength > 0)


### PR DESCRIPTION
Hi, really appreciate your flutter_sound package, but per [this issue](https://github.com/Canardoux/flutter_sound/issues/1204) when using the `toStream` option it generates massive Garbage Collection churn on Android, see this log:
```
2026-01-25 01:19:47.746 27156-27156                 I  Waiting for a blocking GC Alloc
2026-01-25 01:19:47.762 27156-27161                 I  Background young concurrent mark compact GC freed 104MB AllocSpace bytes, 0(0B) LOS objects, 0% free, 255MB/255MB, paused 413us,1.215ms total 302.740ms
2026-01-25 01:19:47.762 27156-27185                 I  WaitForGcToComplete blocked ProfileSaver on Background for 236.711ms
2026-01-25 01:19:47.762 27156-27156                 I  WaitForGcToComplete blocked Alloc on Background for 16.343ms
2026-01-25 01:19:47.762 27156-27156                 I  Starting a blocking GC Alloc
2026-01-25 01:19:47.815 27156-27156                 I  Alloc concurrent mark compact GC freed 250MB AllocSpace bytes, 0(0B) LOS objects, 81% free, 5448KB/29MB, paused 132us,1.471ms total 52.776ms
2026-01-25 01:19:47.815 27156-27161                 I  WaitForGcToComplete blocked Background on Alloc for 49.116ms
2026-01-25 01:19:48.455 27156-27156                 I  Waiting for a blocking GC Alloc
2026-01-25 01:19:48.498 27156-27161                 I  Background concurrent mark compact GC freed 250MB AllocSpace bytes, 0(0B) LOS objects, 81% free, 5460KB/29MB, paused 153us,1.360ms total 199.971ms
2026-01-25 01:19:48.498 27156-27156                 I  WaitForGcToComplete blocked Alloc on Background for 42.261ms
```
That is 604MB collected, causing 107ms of blocked Alloc in less than 1 second (and it goes on forever).

The reason is that in `FlautoRecorderEngine.java` you allocate buffers within a tight loop. I did not have time to look into this in detail, but this PR modifies `FlautoRecorderEngine.java` to use a re-usable buffer that does not have to be allocated frequently, and as a result the blocking GC Alloc calls are gone completely.

Because flutter_sound depends on this repo it is hard to make the change there, but perhaps you can adopt the changes in this PR (or something similar) so that the flutter_sound package becomes much more performant on Android.

Thanks!